### PR TITLE
Update Random-Workshop to print last map's url even if game restarted

### DIFF
--- a/index.json
+++ b/index.json
@@ -112,7 +112,7 @@
       "title": "Randomized Testing Initiative",
       "author": "PortalRunner",
       "description": "Play an endless queue of truly random maps from the Steam workshop. Verifiably impossible puzzles are excluded (e.g. disconnected exit, cube button with no cube, etc.).\n\nThe Epochtal API (epochtal.p2r3.com) is used for these queries. Your account's SteamID and up to 2 played maps may be stored on the server as part of the \"Continue\" feature. No other data processing takes place, and your data will not be used for purposes outside of this feature. This data may be cleared from the server at any point. By using this package, you agree to these terms.",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "args": [],
       "file": "https://github.com/p2r3/spplice-repo/releases/download/latest/random-workshop.tar.xz",
       "icon": "https://p2r3.github.io/spplice-repo/packages/random-workshop/icon.png"

--- a/packages/random-workshop/sources/main.js
+++ b/packages/random-workshop/sources/main.js
@@ -132,8 +132,9 @@ function processConsoleOutput () {
 
     // Process request for a new random map
     if (line.indexOf("Fetching a random map...") !== -1) {
-      // Print the URL for the map the player just completed
-      if (currentMapURL) sendToConsole(gameSocket, 'echo "Completed map\'s URL: ' + currentMapURL + '";echo;echo');
+      // Print the URL for the last map played (fall back to server query if not stored here)
+      const finishedMapURL = currentMapURL || getLastPlayedMapURL();
+      if (finishedMapURL) sendToConsole(gameSocket, 'echo "Previous map\'s URL: ' + finishedMapURL + '";echo;echo');
       // Start a cached map if available, download a new one otherwise
       startMap(nextMap ? nextMap : forceRandomMap(false));
       // Precache the next random map
@@ -183,6 +184,30 @@ function startMap (data) {
   return sendToConsole(gameSocket, 'disconnect;map "' + data.path + '"');
 }
 
+/**
+ * Fetches map data from server and parses it as JSON.
+ * @param {boolean} previous Whether to get the previously downloaded maps
+ */
+function getWorkshopperJson (previous) {
+  const endpoint = previous ? "randomsource" : "random";
+  const json = download.string(HTTP_ADDRESS + "/api/workshopper/" + endpoint + '/"' + steamid + '"');
+  return JSON.parse(json);
+}
+
+/**
+ * Gets the workshop URL for the last map the user played.
+ * Does not download map files.
+ * @returns {string} URL or "" if unavailable
+ */
+function getLastPlayedMapURL () {
+  try {
+    const data = getWorkshopperJson(true);
+    return "https://steamcommunity.com/sharedfiles/filedetails/?id=" + data[0].publishedfileid;
+  } catch (e) {
+    return "";
+  }
+}
+
 // Wrapper for getRandomMap - retries until the procedure succeeds
 function forceRandomMap (previous) {
   try {
@@ -204,10 +229,7 @@ function forceRandomMap (previous) {
  */
 function getRandomMap (previous) {
 
-  // Fetch data from server and parse it as JSON
-  const endpoint = previous ? "randomsource" : "random";
-  const json = download.string(HTTP_ADDRESS + "/api/workshopper/" + endpoint + '/"' + steamid + '"');
-  const data = JSON.parse(json);
+  const data = getWorkshopperJson(previous);
 
   // Depending on the type of query, download either one or two maps
   if (previous) {


### PR DESCRIPTION
The URL of the map the user was last playing was not printed to the console if the game had just restarted.
This meant that if the user received a map that crashes the game as soon as it's opened, the map's URL could not be retrieved by the user.
The previous map's URL is now always printed when the next map starts, even if the game has just been restarted.